### PR TITLE
Support go version < 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Inspired by [GoTTY](https://github.com/yudai/gotty)
 
 ## Installation
 
-1. Import as package to exisitng project.
+1. Import as package to existing project.
     ```bash
     go get github.com/dev6699/rterm
     ```

--- a/ui/src/script.js
+++ b/ui/src/script.js
@@ -66,12 +66,18 @@ socket.addEventListener("message", (event) => {
 });
 
 socket.addEventListener("close", () => {
-    terminal.dispose()
+    if (terminal) {
+        terminal.dispose()
+    }
+    terminalElement.style.display = 'block'
     terminalElement.innerText = "Connection closed"
 })
 
 socket.addEventListener("error", () => {
-    terminal.dispose()
+    if (terminal) {
+        terminal.dispose()
+    }
+    terminalElement.style.display = 'block'
     terminalElement.innerText = "Connection error"
 })
 


### PR DESCRIPTION
### Description

This pull request add support for Go project lower than 1.22.
To fix error `note: module requires Go 1.22`.

### Changes Made
- Replace new go 1.22 routing mechanism with manual route matching.