### PR TITLE
Make buffer size configurable

### DIFF
--- a/cmd/rterm/main.go
+++ b/cmd/rterm/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dev6699/rterm"
 	"github.com/dev6699/rterm/auth"
+	"github.com/gorilla/websocket"
 )
 
 func main() {
@@ -18,6 +19,13 @@ func main() {
 }
 
 func run() error {
+	rterm.SetWSUpgrader(websocket.Upgrader{
+		ReadBufferSize:  1024 * 10e3,
+		WriteBufferSize: 1024 * 10e3,
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+	})
 	rterm.SetPrefix("/")
 	mux := http.NewServeMux()
 

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ func HandleWebSocket(wsUpgrader *websocket.Upgrader, cmd Command) func(http.Resp
 		}
 		defer conn.Close()
 
-		t := tty.New(WSController{Conn: conn}, cmd.Factory)
+		t := tty.New(WSController{Conn: conn}, cmd.Factory, wsUpgrader.ReadBufferSize, wsUpgrader.WriteBufferSize)
 		t.WithWrite(cmd.Writable)
 		t.WithAuthCheck(cmd.AuthCheck)
 

--- a/tty/tty.go
+++ b/tty/tty.go
@@ -19,17 +19,19 @@ type TTY struct {
 	agent Agent
 
 	// mutex to ensure no concurrent write to controller
-	mut        sync.Mutex
-	bufferSize int
-	writable   bool
-	authCheck  auth.AuthCheck
+	mut                  sync.Mutex
+	agentBufferSize      int
+	controllerBufferSize int
+	writable             bool
+	authCheck            auth.AuthCheck
 }
 
-func New(controller Controller, agentFactory AgentFactory) *TTY {
+func New(controller Controller, agentFactory AgentFactory, agentBufferSize int, controllerBufferSize int) *TTY {
 	return &TTY{
-		controller:   controller,
-		agentFactory: agentFactory,
-		bufferSize:   1024,
+		controller:           controller,
+		agentFactory:         agentFactory,
+		agentBufferSize:      agentBufferSize,
+		controllerBufferSize: controllerBufferSize,
 	}
 }
 
@@ -50,7 +52,7 @@ func (t *TTY) Run(ctx context.Context) error {
 	errCh := make(chan error, 2)
 
 	go func() {
-		buf := make([]byte, t.bufferSize)
+		buf := make([]byte, t.agentBufferSize)
 		for {
 			if t.agent == nil {
 				continue
@@ -71,7 +73,7 @@ func (t *TTY) Run(ctx context.Context) error {
 	}()
 
 	go func() {
-		buf := make([]byte, t.bufferSize)
+		buf := make([]byte, t.controllerBufferSize)
 		for {
 			n, err := t.controller.Read(buf)
 			if err != nil {


### PR DESCRIPTION
### Description

This pull request make buffer size configurable by override default `wsUpgrader` with custom read/write buffer size.
Useful for Ctrl C+V large text content.

### Changes Made
- `tty` no longer using hardcoded 1024 buffer size.